### PR TITLE
refactor: removed no necessary enum AmbientTypes.java

### DIFF
--- a/core/src/main/java/io/github/com/ranie_borges/thejungle/model/enums/AmbientTypes.java
+++ b/core/src/main/java/io/github/com/ranie_borges/thejungle/model/enums/AmbientTypes.java
@@ -1,9 +1,0 @@
-package io.github.com.ranie_borges.thejungle.model.enums;
-
-public enum AmbientTypes {
-    CAVE,
-    FOREST,
-    LAKERIVER,
-    MOUNTAIN,
-    RUINS
-}


### PR DESCRIPTION
This pull request includes a change to the `AmbientTypes` enum in the `core/src/main/java/io/github/com/ranie_borges/thejungle/model/enums/AmbientTypes.java` file. The change removes the `AmbientTypes` enum entirely from the codebase.

* [`core/src/main/java/io/github/com/ranie_borges/thejungle/model/enums/AmbientTypes.java`](diffhunk://#diff-59ff1485f5c32d1fe4e6698ecaeeb071a19c6299c978419e22c9385a139adc81L1-L9): Removed the `AmbientTypes` enum which included `CAVE`, `FOREST`, `LAKERIVER`, `MOUNTAIN`, and `RUINS` as its values.